### PR TITLE
change echo to export

### DIFF
--- a/env0.plugin.yml
+++ b/env0.plugin.yml
@@ -11,8 +11,8 @@ inputs:
     description: Additional tfsec flags
 run:
   exec: |
-    echo TFSEC_VERSION="${inputs.version}" >> $ENV0_ENV
-    echo TFSEC_INSTALL_PATH="/home/node/.local/bin" >> $ENV0_ENV
+    export TFSEC_VERSION="${inputs.version}"
+    export TFSEC_INSTALL_PATH="/home/node/.local/bin"
     
     if [ "${TFSEC_VERSION}" == "latest" ]; then echo "This plugin requires a specific tfsec version" && exit 2; fi
     


### PR DESCRIPTION
that fixes the issue of running all commands in the same shell. the values are used within the execution of the plugin thanks to being exported in the traditional way and not written to an environment variables file.